### PR TITLE
Added date parsing for comments of posts

### DIFF
--- a/extractor.js
+++ b/extractor.js
@@ -5,6 +5,20 @@ function getPostId() {
   return postId;
 }
 
+function getCommentId() {
+  console.log(document.querySelector("#url").value);
+  const linkedinURL = decodeURIComponent(document.querySelector("#url").value);
+  const regex = /fsd_comment:\((\d+),urn:li:activity:\d+\)/;
+  const match = regex.exec(linkedinURL);
+  
+  if (match) {
+    const commentId = match[1]; // The captured group
+    return commentId;
+  }
+
+  return null; // or handle the case when no match found
+}
+
 function extractUnixTimestamp(postId) {
   // BigInt needed as we need to treat postId as 64 bit decimal. This reduces browser support.
   const asBinary = BigInt(postId).toString(2);
@@ -15,12 +29,22 @@ function extractUnixTimestamp(postId) {
 
 function unixTimestampToHumanDate(timestamp) {
   const dateObject = new Date(timestamp);
-  const humanDateFormat = dateObject.toUTCString()+" (UTC)";
+  const humanDateFormat = dateObject.toUTCString() + " (UTC)";
   return humanDateFormat;
 }
 
 function getDate() {
   const postId = getPostId();
+  const commentId = getCommentId();
+  console.log(commentId);
+  
+  if (commentId) {
+    const unixTimestamp = extractUnixTimestamp(commentId);
+    const humanDateFormat = unixTimestampToHumanDate(unixTimestamp);
+    document.querySelector("#date").textContent = humanDateFormat;
+    return;
+  }
+
   const unixTimestamp = extractUnixTimestamp(postId);
   const humanDateFormat = unixTimestampToHumanDate(unixTimestamp);
   document.querySelector("#date").textContent = humanDateFormat;


### PR DESCRIPTION
If a comment is URL is detected that is displayed, otherwise the default functionality still occurs. 